### PR TITLE
Refactor accessibility fallback search pattern

### DIFF
--- a/Source/MonitorController.swift
+++ b/Source/MonitorController.swift
@@ -5,10 +5,10 @@ final class MonitorController {
     case resize, drag, ended
   }
 
-  private var monitor: Any?
+  private var flagMonitor: Any?
 
   func start(_ handler: @escaping (State) -> Void) {
-    monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { event in
+    flagMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { event in
       if event.modifierFlags.contains(.capsLock) || event.modifierFlags.contains(.option) ||
         event.modifierFlags.contains(.control) {
         handler(.ended)
@@ -30,7 +30,8 @@ final class MonitorController {
   }
 
   func end() {
-    guard let monitor = monitor else { return }
-    NSEvent.removeMonitor(monitor)
+    if let flagMonitor = flagMonitor {
+      NSEvent.removeMonitor(flagMonitor)
+    }
   }
 }


### PR DESCRIPTION
Instead of using `while keepSearching`, we now
have a `findElement(at)` method that is recursive.
It follows the same principal as in it will continue
to search for a window by decrementing the y coordinate
until it will eventually hit the toolbar or end up
returning `nil`.

It also has a global `isSearching` boolean that will
help to stop unnecessary lookup. If the `state` is
`.ended`, any ongoing searches should stop.
This improves reliability, performance and most importantly
it makes the user experience more seemless.