### PR TITLE
Make logo in README.md scale properly on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## MouseDef
 
 <p align="center">
- <img src="https://raw.githubusercontent.com/zenangst/MouseDef/master/Images/MouseDef.png" alt="MouseDef" width="512" height="512" align="center" />
+ <img src="https://raw.githubusercontent.com/zenangst/MouseDef/master/Images/MouseDef.png" alt="MouseDef" width="512" align="center" />
 </p>
 
 ⚠️ This application is in its alpha stage, things may change drastically going forward. ⚠️


### PR DESCRIPTION
On smaller devices the logo gets "squished" because of the fixed height of the image. This simply removes the height attribute.

<details>
  <summary>Screenshot of problem</summary>
  
  ![problem](https://i.imgur.com/et07i1m.png)
</details>